### PR TITLE
Allow minimum saturation of 0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,11 @@ through antialiasing are not present.
 Changelog
 ---------
 
+dev
+~~~
+
+- Allow shades by setting --min-saturation=0
+
 0.3.0
 ~~~~~
 

--- a/colorific/palette.py
+++ b/colorific/palette.py
@@ -248,7 +248,7 @@ def save_palette_as_image(filename, palette):
 
 
 def meets_min_saturation(c, threshold):
-    return colorsys.rgb_to_hsv(*norm_color(c.value))[1] > threshold
+    return colorsys.rgb_to_hsv(*norm_color(c.value))[1] >= threshold
 
 
 def autocrop(im, bgcolor):

--- a/tests/test_colorific.py
+++ b/tests/test_colorific.py
@@ -33,6 +33,16 @@ class ExtractionTest(unittest.TestCase):
         found = [c.value for c in p.colors]
         self.assertEquals(found, expected)
 
+    def test_extraction_without_saturation_filter(self):
+        expected = [(0, 101, 185),
+                    (255, 255, 255),
+                    (187, 214, 236),
+                    (255, 0, 0)]
+        p = palette.extract_colors(self.filename, min_saturation=0)
+        found = [c.value for c in p.colors]
+        self.assertEquals(found, expected)
+        self.assertEquals(p.bgcolor.value, (0, 0, 0))
+
 
 class ConversionTest(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Fix the case where `--min-saturation=0`, which should allow black and white into the picture.
