### PR TITLE
Exit 0 on successful invoke with images as args.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,11 @@ through antialiasing are not present.
 Changelog
 ---------
 
+dev
+~~~
+
+- Fix: exit 0 when successfully invoked with args
+
 0.3.0
 ~~~~~
 

--- a/colorific/script.py
+++ b/colorific/script.py
@@ -104,6 +104,8 @@ class Application(object):
                 if options.save_palette:
                     save_palette_as_image(filename, palette)
 
+                sys.exit(0)
+
             sys.exit(1)
 
         if options.n_processes > 1:


### PR DESCRIPTION
A fix for https://github.com/99designs/colorific/issues/21
